### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <artifactId>CucumberBasics</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-         <maven.compiler.source>1.6</maven.compiler.source>
-         <maven.compiler.target>1.6</maven.compiler.target>
+         <maven.compiler.source>1.8</maven.compiler.source>
+         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
 


### PR DESCRIPTION
Hi, when I follow the udemy course Learn Jenkins 2.0 for end-to-end testing of applications (https://meridianlink.udemy.com/course/working-with-jenkins/learn/lecture/6712252#overview) this example does not work any more and I see error message like "[ERROR] Source option 6 is no longer supported. Use 7 or later."